### PR TITLE
Snes9x - SuperFX overclock value will properly load on next boot (InfiniteBlueGX)

### DIFF
--- a/source/snes9xgx.cpp
+++ b/source/snes9xgx.cpp
@@ -60,6 +60,7 @@ int ExitRequested = 0;
 bool isWiiVC = false;
 char appPath[1024] = { 0 };
 static int currentMode;
+bool firstRun = true;
 
 extern "C" {
 #ifdef USE_VM
@@ -479,27 +480,6 @@ int main(int argc, char *argv[])
 		autoboot = GCSettings.AutoloadGame;
 	}
 
-	switch (GCSettings.sfxOverclock)
-	{
-		case 0: Settings.SuperFXSpeedPerLine = 5823405; break;
-		case 1: Settings.SuperFXSpeedPerLine = 0.417 * 20.5e6; break;
-		case 2: Settings.SuperFXSpeedPerLine = 0.417 * 40.5e6; break;
-		case 3: Settings.SuperFXSpeedPerLine = 0.417 * 60.5e6; break;
-	}
-
-	if (GCSettings.sfxOverclock > 0)
-	{
-		S9xResetSuperFX();
-		S9xReset();
-	}
-
-	switch (GCSettings.Interpolation)
-	{
-		case 0: Settings.InterpolationMethod = DSP_INTERPOLATION_GAUSSIAN; break;
-		case 1: Settings.InterpolationMethod = DSP_INTERPOLATION_LINEAR; break;
-		case 2: Settings.InterpolationMethod = DSP_INTERPOLATION_NONE; break;
-	}
-
 	while (1) // main loop
 	{
 		if(!autoboot) {
@@ -518,6 +498,30 @@ int main(int argc, char *argv[])
 #ifdef HW_RVL
 		SelectFilterMethod();
 #endif
+		if (firstRun)
+		{
+			firstRun = false;
+			switch (GCSettings.sfxOverclock)
+			{
+				case 0: Settings.SuperFXSpeedPerLine = 5823405; break;
+				case 1: Settings.SuperFXSpeedPerLine = 0.417 * 20.5e6; break;
+				case 2: Settings.SuperFXSpeedPerLine = 0.417 * 40.5e6; break;
+				case 3: Settings.SuperFXSpeedPerLine = 0.417 * 60.5e6; break;
+			}
+
+			if (GCSettings.sfxOverclock > 0)
+			S9xResetSuperFX();
+			else
+			S9xReset();
+
+			switch (GCSettings.Interpolation)
+			{
+			case 0: Settings.InterpolationMethod = DSP_INTERPOLATION_GAUSSIAN; break;
+			case 1: Settings.InterpolationMethod = DSP_INTERPOLATION_LINEAR; break;
+			case 2: Settings.InterpolationMethod = DSP_INTERPOLATION_NONE; break;
+			}
+		}
+		
 		autoboot = false;		
 		ConfigRequested = 0;
 		ScreenshotRequested = 0;


### PR DESCRIPTION
With this modification now the Super FX overclock value set up in the Video Settings menu, the desired value set will be saved for the next boot of Snes9x GX.

Very useful when you make custom Single ROM Loaders (SRLs) for those "heavy" SNES Super FX games which require some a bit speed, even this could be used on WiiFlow.

Based on @InfiniteBlueGX's code :)